### PR TITLE
remove and or operations from finding in source code

### DIFF
--- a/stylechecker
+++ b/stylechecker
@@ -39,7 +39,7 @@ grep -w -E "(if)|(case)|(while)|(for)" $trimmed
 echo "============================"
 cc2=`grep -E "(\?)" -o $trimmed | wc -l`
 echo "? found:" $cc2
-grep -E "(\?)|(&&)|(\|\|)" $trimmed
+grep -E "(\?)" $trimmed
 echo "============================"
 echo "estimated cyclomatic complexity:" $(( $cc1 + $cc2 ))
 echo "============================"


### PR DESCRIPTION
Remove the and or operations from finding in the source code.
## Before
![image](https://user-images.githubusercontent.com/1884076/143183333-0785a2d1-6b29-4a1f-a720-be72adefdb08.png)

## After
![image](https://user-images.githubusercontent.com/1884076/143183458-ea47d940-dfc7-4e15-aec5-512cacad57b0.png)
