### PR TITLE
fix omitted global variables

### DIFF
--- a/stylechecker
+++ b/stylechecker
@@ -29,7 +29,7 @@ fi
 
 $compiler -g $filename
 nmlist=`mktemp`
-global=`nm -l a.out | grep ":" | grep "[0-8] [^T]" | awk '{sub(/^.*\//, "", $4); print $3 " in " $4}' | tee $nmlist | wc -l`
+global=`nm -l a.out | grep ":" | grep "[0-9a-f] [^T]" | awk '{sub(/^.*\//, "", $4); print $3 " in " $4}' | tee $nmlist | wc -l`
 echo "global variables found:" $global
 cat $nmlist
 echo "============================"


### PR DESCRIPTION
Fix omitted global variables. The checked source code can be found at [JudgeGirl highlight](https://judgegirl.csie.org/source/highlight/423439).

The symbol values from `nm` is hexadecimal.

## Before
### Stylechecker Output
![image](https://user-images.githubusercontent.com/1884076/143185430-7d6cad4d-8935-46c5-bc53-0f12d61a58af.png)

### `nm` Output
![image](https://user-images.githubusercontent.com/1884076/143185202-81d31b7b-b04a-4ed0-8b7b-55d34dfeb3b5.png)

## After
### Stylechecker Output
![image](https://user-images.githubusercontent.com/1884076/143185503-f5a7985d-686e-4589-a968-8ff1e4a19ae5.png)
